### PR TITLE
Node 4+ compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: node_js
 node_js:
 - 0.10
+- 4.1
+- stable
 
 env:
   matrix:
@@ -29,4 +31,4 @@ after_failure:
 
 notifications:
   email:
-  - damon.oehlman@nicta.com.au
+  - nathan.oehlman@nicta.com.au

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "messenger-memory": "^2.0.0",
     "rtc-signaller-testrun": "^1.2.2",
     "rtc-switchboard": "^3.0.0",
-    "rtc-switchboard-messenger": "^1.0.0",
+    "rtc-switchboard-messenger": "^2.0.0",
     "tap-spec": "^3.0.0",
     "tape": "^4.0.0",
     "travis-multirunner": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "rtc-switchboard-messenger": "^2.0.0",
     "tap-spec": "^3.0.0",
     "tape": "^4.0.0",
-    "travis-multirunner": "^2.7.2",
+    "travis-multirunner": "^3.0.0",
     "whisk": "^1.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "messenger-memory": "^2.0.0",
     "rtc-signaller-testrun": "^1.2.2",
     "rtc-switchboard": "^3.0.0",
-    "rtc-switchboard-messenger": "^2.0.0",
+    "rtc-switchboard-messenger": "^2.0.3",
     "tap-spec": "^3.0.0",
     "tape": "^4.0.0",
     "travis-multirunner": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "signalling"
   ],
   "author": "Damon Oehlman <damon.oehlman@nicta.com.au>",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/rtc-io/rtc-signaller/issues"
   }


### PR DESCRIPTION
Fixes the issue with `bufferutil` and `utf-8-validate` from `ws` (issue #37), and adds testing against more Node versions.